### PR TITLE
build: disable ESLint in the build process

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
### **Pull Request Description: Disable ESLint in Build Process**

This pull request disables ESLint in the build process to prevent linting errors from interrupting the build workflow. This change is temporary and can be revisited in future updates.
